### PR TITLE
Remove unused types warning

### DIFF
--- a/src/State/NLPAtXmod.jl
+++ b/src/State/NLPAtXmod.jl
@@ -81,7 +81,7 @@ mutable struct NLPAtX{Score, S, T <: AbstractVector} <: AbstractState{S, T}
     d::T = _init_field(T),
     res::T = _init_field(T),
     current_time::Float64 = NaN,
-  ) where {Score, S, T <: AbstractVector}
+  ) where {Score, T <: AbstractVector}
     _size_check(x, lambda, fx, gx, Hx, mu, cx, Jx)
 
     return new{Score, eltype(T), T}(

--- a/src/Stopping/NLPStoppingmod.jl
+++ b/src/Stopping/NLPStoppingmod.jl
@@ -309,7 +309,6 @@ function fill_in!(
   SRC <: AbstractStopRemoteControl,
   MStp,
   LoS <: AbstractListofStates,
-  Score,
   S,
   T,
 }


### PR DESCRIPTION
```
┌ Stopping [c4fe5a9e-e7fb-5c3d-89d5-7f405ab2214f]
│  WARNING: method definition for _#16 at /home/p114363/.julia/packages/Stopping/nFb7K/src/State/NLPAtXmod.jl:71 declares type variable S but does not use it.
│  WARNING: method definition for #fill_in!#96 at /home/p114363/.julia/packages/Stopping/nFb7K/src/Stopping/NLPStoppingmod.jl:297 declares type variable Score but does not use it.
└  
```